### PR TITLE
number[] to ArraySchema<number>

### DIFF
--- a/server/rooms/tictactoe.ts
+++ b/server/rooms/tictactoe.ts
@@ -7,7 +7,7 @@ const BOARD_WIDTH = 3;
 class State extends Schema {
   @type("string") currentTurn: string;
   @type({ map: "boolean" }) players = new MapSchema<boolean>();
-  @type(["number"]) board: number[] = new ArraySchema<number>(0, 0, 0, 0, 0, 0, 0, 0, 0);
+  @type(["number"]) board: ArraySchema<number> = new ArraySchema<number>(0, 0, 0, 0, 0, 0, 0, 0, 0);
   @type("string") winner: string;
   @type("boolean") draw: boolean;
 }


### PR DESCRIPTION
Typescript gives me on error with the current code:
```
TSError: ⨯ Unable to compile TypeScript:
rooms/tictactoe.ts:10:21 - error TS2322: Type 'ArraySchema<number>' is not assignable to type 'number[]'.
  Types of property 'every' are incompatible.
    Type '(callbackfn: (value: number, index: number, array: number[]) => unknown, thisArg?: any) => boolean' is not assignable to type '{ <S extends number>(predicate: (value: number, index: number, array: number[]) => value is S, thisArg?: any): this is S[]; (predicate: (value: number, index: number, array: number[]) => unknown, thisArg?: any): boolean; }'.
      Signature '(callbackfn: (value: number, index: number, array: number[]) => unknown, thisArg?: any): boolean' must be a type predicate.

10   @type(["number"]) board: number[] = new ArraySchema<number>(0, 0, 0, 0, 0, 0, 0, 0, 0);
                       ~~~~~
```
The PR fixes the compilation errors. 